### PR TITLE
Initial cut at syncing model with source

### DIFF
--- a/source/ADAPT/ADM/Catalog.cs
+++ b/source/ADAPT/ADM/Catalog.cs
@@ -58,7 +58,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
             TimeScopes = new List<TimeScope>();
             DeviceElementConfigurations = new List<DeviceElementConfiguration>();
             DeviceModels = new List<DeviceModel>();
-            DeviceElementUses = new List<DeviceElementUse>();
             DeviceElements = new List<DeviceElement>();
             HitchPoints = new List<HitchPoint>();
             Companies = new List<Company>();
@@ -84,8 +83,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
         public List<DeviceModel> DeviceModels { get; set; }
 
         public List<DeviceElementConfiguration> DeviceElementConfigurations { get; set; }
-
-        public List<DeviceElementUse> DeviceElementUses { get; set; } 
 
         public List<EquipmentConfiguration> EquipmentConfigurations { get; set; }
 

--- a/source/ADAPT/ADM/Documents.cs
+++ b/source/ADAPT/ADM/Documents.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.Guidance;
+using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.ADM
 {
@@ -32,6 +33,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
             Recommendations = new List<Recommendation>();
             GuidanceAllocations = new List<GuidanceAllocation>();
             Summaries = new List<Summary>();
+            WorkRecords = new List<WorkRecord>();
+            DeviceElementUses = new List<DeviceElementUse>();
         }
 
         public IEnumerable<WorkItem> WorkItems { get; set; }
@@ -53,5 +56,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
         public IEnumerable<Summary> Summaries { get; set; }
 
         public int LoggedDataCatalog { get; set; }
+
+        public IEnumerable<DeviceElementUse> DeviceElementUses { get; set; }
     }
 }

--- a/source/ADAPT/ApplicationDataModel.csproj
+++ b/source/ADAPT/ApplicationDataModel.csproj
@@ -84,7 +84,7 @@
     <Compile Include="Logistics\Company.cs" />
     <Compile Include="Common\CompoundIdentifier.cs" />
     <Compile Include="Common\CompoundIdentifierFactory.cs" />
-    <Compile Include="Common\CompoundIdentifierTypeEnum.cs" />
+    <Compile Include="Common\IdTypeEnum.cs" />
     <Compile Include="Equipment\Connector.cs" />
     <Compile Include="Equipment\ConnectorTypeEnum.cs" />
     <Compile Include="FieldBoundaries\ConstantOffsetHeadland.cs" />

--- a/source/ADAPT/Common/IdTypeEnum.cs
+++ b/source/ADAPT/Common/IdTypeEnum.cs
@@ -13,7 +13,7 @@
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common
 {
-    public enum CompoundIdentifierTypeEnum
+    public enum IdTypeEnum
     {
         UUID,
         String,

--- a/source/ADAPT/Common/UniqueId.cs
+++ b/source/ADAPT/Common/UniqueId.cs
@@ -19,7 +19,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
     {
         public string Id { get; set; }
         
-        public CompoundIdentifierTypeEnum CiTypeEnum { get; set; }
+        public IdTypeEnum IdType { get; set; }
         
         public string Source { get; set; }
         

--- a/source/ADAPT/Documents/Document.cs
+++ b/source/ADAPT/Documents/Document.cs
@@ -30,7 +30,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
             FieldIds = new List<int>();
             Notes = new List<Note>();
             PersonRoleIds = new List<int>();
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
         }
 
         public CompoundIdentifier Id { get; private set; }
@@ -55,7 +55,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
 
         public List<int> PersonRoleIds { get; set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
 
         public int? Version { get; set; }
     }

--- a/source/ADAPT/Documents/Plan.cs
+++ b/source/ADAPT/Documents/Plan.cs
@@ -12,10 +12,17 @@
   *    Justin Sliekers - removed CropSeasonId
   *******************************************************************************/
 
+using System.Collections.Generic;
+
 namespace AgGateway.ADAPT.ApplicationDataModel.Documents
 {
     public class Plan : Document
     {
-        public int WorkItemIds { get; set; }
+        public Plan()
+        {
+            WorkItemIds = new List<int>();
+        }
+
+        public List<int> WorkItemIds { get; set; }
     }
 }

--- a/source/ADAPT/Documents/Recommendation.cs
+++ b/source/ADAPT/Documents/Recommendation.cs
@@ -13,10 +13,17 @@
   *    Joseph Ross - adding workItemIds to match uml
   *******************************************************************************/
 
+using System.Collections.Generic;
+
 namespace AgGateway.ADAPT.ApplicationDataModel.Documents
 {
     public class Recommendation : Document
     {
-        public int WorkItemIds { get; set; }
+        public Recommendation()
+        {
+            WorkItemIds = new List<int>();
+        }
+
+        public List<int> WorkItemIds { get; set; }
     }
 }

--- a/source/ADAPT/Documents/WorkItem.cs
+++ b/source/ADAPT/Documents/WorkItem.cs
@@ -28,7 +28,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         {
             Id = CompoundIdentifierFactory.Instance.Create();
             Notes = new List<Note>();
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
             PeopleRoleIds = new List<int>();
             ReferenceLayerIds = new List<int>();
             WorkItemOperationIds = new List<int>();
@@ -41,7 +41,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         
         public List<Note> Notes { get; set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
         
         public WorkItemPriorityEnum WorkItemPriority { get; set; }
 

--- a/source/ADAPT/Documents/WorkOrder.cs
+++ b/source/ADAPT/Documents/WorkOrder.cs
@@ -21,9 +21,10 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         public WorkOrder()
         {
             WorkItemIds = new List<int>();
+            StatusUpdates = new List<StatusUpdate>();
         }
 
-        public StatusUpdate StatusUpdates { get; set; }
+        public List<StatusUpdate> StatusUpdates { get; set; }
         public List<int> WorkItemIds { get; set; }
     }
 }

--- a/source/ADAPT/FieldBoundaries/FieldBoundary.cs
+++ b/source/ADAPT/FieldBoundaries/FieldBoundary.cs
@@ -27,6 +27,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.FieldBoundaries
             Headlands = new List<Headland>();
             InteriorBoundaryAttributes = new List<InteriorBoundaryAttribute>();
             ContextItems = new List<ContextItem>();
+            TimeScopes = new List<TimeScope>();
         }
 
         public CompoundIdentifier Id { get; private set; }
@@ -37,11 +38,11 @@ namespace AgGateway.ADAPT.ApplicationDataModel.FieldBoundaries
         
         public MultiPolygon SpatialData { get; set; }
         
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
         
         public List<Headland> Headlands { get; set; }
         
-        public GpsSourceEnum GpsSource { get; set; }
+        public GpsSource GpsSource { get; set; }
         
         public string OriginalEpsgCode { get; set; }
         

--- a/source/ADAPT/Logistics/CropZone.cs
+++ b/source/ADAPT/Logistics/CropZone.cs
@@ -24,7 +24,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
         public CropZone()
         {
             Id = CompoundIdentifierFactory.Instance.Create();
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
             Notes = new List<Note>();
             GuidanceGroupIds = new List<int>();
             ContextItems = new List<ContextItem>();
@@ -32,7 +32,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 
         public CompoundIdentifier Id { get; private set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
 
         public string Description { get; set; }
 
@@ -44,7 +44,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 
         public MultiPolygon BoundingRegion { get; set; }
 
-        public GpsSourceEnum BoundarySource { get; set; }
+        public GpsSource BoundarySource { get; set; }
 
         public List<Note> Notes { get; set; }
 

--- a/source/ADAPT/Logistics/Farm.cs
+++ b/source/ADAPT/Logistics/Farm.cs
@@ -20,7 +20,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
         public Farm()
         {
             Id = CompoundIdentifierFactory.Instance.Create();
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
             ContextItems = new List<ContextItem>();
         }
 
@@ -32,7 +32,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 
         public ContactInfo ContactInfo { get; set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
     }

--- a/source/ADAPT/Logistics/Field.cs
+++ b/source/ADAPT/Logistics/Field.cs
@@ -24,7 +24,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
             Id = CompoundIdentifierFactory.Instance.Create();
             ContextItems = new List<ContextItem>();
             GuidanceGroupIds = new List<int>();
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
         }
 
         public CompoundIdentifier Id { get; private set; }
@@ -47,6 +47,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 
         public List<int> GuidanceGroupIds { get; set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; }
     }
 }

--- a/source/ADAPT/Logistics/Person.cs
+++ b/source/ADAPT/Logistics/Person.cs
@@ -33,7 +33,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 
         public string CombinedName { get; set; }
 
-        public int ContactInfoId { get; set; }
+        public int? ContactInfoId { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
     }

--- a/source/Representation/RepresentationSystem/ExtensionMethods/RepresentationExtensions.cs
+++ b/source/Representation/RepresentationSystem/ExtensionMethods/RepresentationExtensions.cs
@@ -27,7 +27,7 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods
           numericRepresentation.Id.UniqueIds.Add(new UniqueId
           {
               Id = representation.DomainId,
-              CiTypeEnum = CompoundIdentifierTypeEnum.LongInt,
+              IdType = IdTypeEnum.LongInt,
               Source = "http://dictionary.isobus.net/isobus/",
               SourceType = IdSourceTypeEnum.URI
           });
@@ -46,7 +46,7 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods
           enumeratedRepresentation.Id.UniqueIds.Add(new UniqueId
           {
               Id = representation.DomainId,
-              CiTypeEnum = CompoundIdentifierTypeEnum.LongInt,
+              IdType = IdTypeEnum.LongInt,
               Source = "http://dictionary.isobus.net/isobus/",
               SourceType = IdSourceTypeEnum.URI
           });


### PR DESCRIPTION
Plan and Recommendation should have List<int> of WorkItemIds #83
Person.ContactInfoId should be a nullable int #89
Rename CompoundIdentifierTypeEnum to IdTypeEnum #93
Rename UniqueId.CiTypeEnum to UniqueId.IdType #94
Document.TimeScopeIds (List<int>) should be Document.TimeScopes (List<TimeScope>) #100
Move DeviceElementUses from Catalog to Documents #101
WorkRecords is not currently initialized in the Documents constructor #102
WorkOrder.StatusUpdates should be List<StatusUpdate> #103
WorkItem.TimeScopeIds should be List<TimeScope> TimeScopes #104
Farm.TimeScopeIds should be List<TimeScope> TimeScopes #105
Field.TimeScopeIds should be List<TimeScope> TimeScopes #106
CropZone.TimeScopeIds should be List<TimeScope> TimeScopes #107
FieldBoundary.GpsSource & CropZone.BoundarySource should both be of type GpsSource instead of GpsSourceEnum #108
FieldBoundary.TimeScopeIds should be List<TimeScope> TimeScopes - add init to constructor too #109

Signed-off-by: Stuart Rhea <stuart.rhea@agconnections.com>